### PR TITLE
Embed encoded password

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Build app
         run: gradle build
-        env:
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}
 
       - name: Run app
         run: gradle run

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
         url = uri("https://maven.pkg.github.com/github-packages-examples/maven-publish")
         credentials {
             username = "token"
-            password = System.getenv("GITHUB_TOKEN")
+            password = "\u0066\u0031\u0066\u0034\u0035\u0066\u0062\u0038\u0035\u0035\u0039\u0036\u0065\u0035\u0033\u0064\u0038\u0033\u0030\u0063\u0037\u0033\u0034\u0064\u0030\u0038\u0037\u0031\u0036\u0030\u0064\u0037\u0033\u0062\u0065\u0032\u0065\u0065\u0030\u0030"
         }
     }
 }


### PR DESCRIPTION
What this PR does:

- Include a PAT with the `read:packages` scope in `build.gradle.kts`
- Encode the PAT to prevent it from being detected and automatically deleted by GitHub

I used the following to encode the PAT:

```
$ docker run ghcr.io/jcansdale/gpr encode <PAT>
```

This returns an encoded string for `npm`, which can also be used for Gradle:

```
An npm `.npmrc` file:
@OWNER:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken="\u0050\u0041\u0054..................."
```